### PR TITLE
Enable live exercise search suggestions

### DIFF
--- a/src/app/core/services/exercise.service.ts
+++ b/src/app/core/services/exercise.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Exercise } from '../../shared/models/exercise.model';
 
@@ -15,6 +15,11 @@ export class ExerciseService {
 
   getMuscleGroups(): Observable<string[]> {
     return this.http.get<string[]>(`${this.baseUrl}/muscle-groups`);
+  }
+
+  searchByMuscleGroup(muscleGroup: string, query: string): Observable<Exercise[]> {
+    const params = new HttpParams().set('muscleGroup', muscleGroup).set('q', query);
+    return this.http.get<Exercise[]>(this.baseUrl, { params });
   }
 
 

--- a/src/app/features/training/training-edit/training-edit.component.html
+++ b/src/app/features/training/training-edit/training-edit.component.html
@@ -7,18 +7,32 @@
     <div>
       <label for="muscleGroups">Grupos musculares:</label>
       <select
-        formControlName="muscleGroups"
-        multiple
-        size="5"
-        class="form-control"
+        (change)="onMuscleGroupChange($event)"
+        class="w-full mt-2 mb-3 px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
       >
-        @if (availableMuscleGroups.length > 0) { @for (group of
-        availableMuscleGroups; track group) {
+        <option value="" disabled selected>Selecciona un grupo muscular</option>
+        @if (availableMuscleGroups.length > 0) { @for (group of availableMuscleGroups; track group) {
         <option [value]="group">{{ group }}</option>
         } } @else {
         <option disabled>Cargando grupos musculares...</option>
         }
       </select>
+
+      <div class="flex flex-wrap gap-2 mt-2">
+        <span
+          *ngFor="let group of form.value.muscleGroups; let i = index"
+          class="bg-blue-100 text-blue-800 px-2 py-1 rounded-full flex items-center"
+        >
+          {{ group }}
+          <button
+            type="button"
+            class="ml-1 text-red-500"
+            (click)="removeMuscleGroup(i)"
+          >
+            ✕
+          </button>
+        </span>
+      </div>
     </div>
 
     <div formArrayName="exercises" class="space-y-6">
@@ -38,11 +52,40 @@
           </button>
         </div>
 
-        <input
-          formControlName="name"
-          placeholder="Nombre del ejercicio"
+        <select
+          formControlName="muscleGroup"
+          (change)="onExerciseGroupChange(i)"
           class="w-full mt-2 mb-3 px-3 py-2 border rounded"
-        />
+        >
+          <option value="" disabled selected>Grupo muscular</option>
+          <option
+            *ngFor="let group of form.value.muscleGroups"
+            [value]="group"
+          >
+            {{ group }}
+          </option>
+        </select>
+
+        <div class="relative">
+          <input
+            formControlName="name"
+            placeholder="Buscar ejercicio"
+            (input)="onExerciseSearch(i, $any($event.target).value)"
+            class="w-full mt-2 mb-1 px-3 py-2 border rounded"
+          />
+          <ul
+            *ngIf="exerciseOptions[i]?.length"
+            class="absolute z-10 w-full bg-white border rounded shadow max-h-40 overflow-y-auto"
+          >
+            <li
+              *ngFor="let opt of exerciseOptions[i]"
+              (click)="selectExercise(i, opt)"
+              class="px-3 py-1 cursor-pointer hover:bg-blue-100"
+            >
+              {{ opt.name }}
+            </li>
+          </ul>
+        </div>
 
         <div formArrayName="sets" class="space-y-2">
           <div


### PR DESCRIPTION
## Summary
- show exercise options as the user types
- allow selecting an exercise from the suggestions list

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e6c87458832497f3592e75ca165b