### PR TITLE
Add sidebar navigation and exercise filtering

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,9 @@
 <app-header></app-header>
-<router-outlet></router-outlet>
+<div class="flex min-h-screen">
+  @if (auth.isLoggedIn) {
+    <app-side-menu></app-side-menu>
+  }
+  <main class="flex-1 p-4">
+    <router-outlet></router-outlet>
+  </main>
+</div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,12 +1,17 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { HeaderComponent } from './shared/components/header/header.component';
+import { SideMenuComponent } from './shared/components/side-menu/side-menu.component';
+import { CommonModule } from '@angular/common';
+import { AuthService } from './core/services/auth.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, HeaderComponent],
+  imports: [CommonModule, RouterOutlet, HeaderComponent, SideMenuComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {}
+export class AppComponent {
+  auth = inject(AuthService);
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,9 +6,22 @@ import { TrainingEditComponent } from './features/training/training-edit/trainin
 export const appRoutes: Routes = [
   {
     path: '',
+    redirectTo: 'calendar',
+    pathMatch: 'full'
+  },
+  {
+    path: 'calendar',
     loadComponent: () =>
       import('./features/calendar/calendar.component').then(
         (m) => m.CalendarComponent
+      ),
+    canActivate: [AuthGuard],
+  },
+  {
+    path: 'exercises',
+    loadComponent: () =>
+      import('./features/exercises/exercise-list/exercise-list.component').then(
+        (m) => m.ExerciseListComponent
       ),
     canActivate: [AuthGuard],
   },

--- a/src/app/features/exercises/exercise-list/exercise-list.component.html
+++ b/src/app/features/exercises/exercise-list/exercise-list.component.html
@@ -1,5 +1,15 @@
 <h2 class="text-xl font-bold mb-4">Listado de ejercicios</h2>
 
+<div class="mb-4">
+  <label class="mr-2">Filtrar por grupo muscular:</label>
+  <select (change)="changeMuscle($event)" class="border p-1">
+    <option value="">Todos</option>
+    @for (group of muscleGroups(); track group) {
+      <option [value]="group">{{ group }}</option>
+    }
+  </select>
+</div>
+
 @if (loading()) {
   <div>Cargando ejercicios...</div>
 } @else {

--- a/src/app/shared/components/side-menu/side-menu.component.html
+++ b/src/app/shared/components/side-menu/side-menu.component.html
@@ -1,0 +1,10 @@
+<nav class="w-48 bg-gray-100 p-4 h-full">
+  <ul class="space-y-2">
+    <li>
+      <a routerLink="/calendar" routerLinkActive="font-bold" class="block">Calendario</a>
+    </li>
+    <li>
+      <a routerLink="/exercises" routerLinkActive="font-bold" class="block">Ejercicios</a>
+    </li>
+  </ul>
+</nav>

--- a/src/app/shared/components/side-menu/side-menu.component.scss
+++ b/src/app/shared/components/side-menu/side-menu.component.scss
@@ -1,0 +1,1 @@
+/* empty for now */

--- a/src/app/shared/components/side-menu/side-menu.component.ts
+++ b/src/app/shared/components/side-menu/side-menu.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-side-menu',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './side-menu.component.html',
+  styleUrls: ['./side-menu.component.scss'],
+})
+export class SideMenuComponent {}


### PR DESCRIPTION
## Summary
- create a reusable `SideMenuComponent`
- show the sidebar in `AppComponent` when logged in
- add `/calendar` and `/exercises` routes
- enable filtering in `ExerciseListComponent`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847371cc1288324818f1fc3c85c2bcb