### PR TITLE
Add welcome and logout to sidebar

### DIFF
--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -1,28 +1,18 @@
-<header class="flex items-center justify-between p-4 bg-gray-800 text-white">
-  <div class="flex items-center">
-    @if (auth.isLoggedIn) {
-      <button
-        (click)="menuToggle.emit()"
-        class="mr-2 bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded"
-      >
-        ☰
-      </button>
-    }
-    <div class="text-xl font-bold">GYM APP</div>
-  </div>
-  @if(auth.isLoggedIn) {
-  <div>
-    Bienvenido, {{ auth.user?.username }}
+<header class="relative flex items-center justify-center p-4 bg-gray-800 text-white">
+  @if (auth.isLoggedIn) {
     <button
-      (click)="logout()"
-      class="ml-4 bg-red-600 hover:bg-red-700 px-3 py-1 rounded"
+      (click)="menuToggle.emit()"
+      class="absolute left-4 bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded"
     >
-      Cerrar sesión
+      ☰
     </button>
-  </div>
-  } @else {
-  <a routerLink="/login" class="text-blue-300 hover:underline"
-    >Iniciar sesión</a
-  >
+  }
+  <div class="text-xl font-bold">GYM APP</div>
+  @if (!auth.isLoggedIn) {
+    <a
+      routerLink="/login"
+      class="absolute right-4 text-blue-300 hover:underline"
+      >Iniciar sesión</a
+    >
   }
 </header>

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -13,8 +13,4 @@ import { AuthService } from '../../../core/services/auth.service';
 export class HeaderComponent {
   @Output() menuToggle = new EventEmitter<void>();
   constructor(public auth: AuthService) {}
-
-  logout() {
-    this.auth.logout();
-  }
 }

--- a/src/app/shared/components/side-menu/side-menu.component.html
+++ b/src/app/shared/components/side-menu/side-menu.component.html
@@ -1,14 +1,30 @@
-<nav class="w-48 bg-gray-100 p-4 h-full shadow-lg">
+<nav
+  class="w-56 bg-gray-800 text-white p-4 h-full shadow-lg"
+  [@slideInOut]
+>
   <button
     (click)="closeMenu.emit()"
-    class="mb-4 text-sm text-gray-700 hover:underline"
-  >Cerrar</button>
+    class="mb-4 mr-2 bg-gray-700 hover:bg-gray-600 px-2 py-1 rounded"
+  >
+    ☰
+  </button>
+  <div class="mb-4">Bienvenido, {{ auth.user?.username }}</div>
+  <button
+    (click)="logout()"
+    class="mb-6 bg-red-600 hover:bg-red-700 px-3 py-1 rounded"
+  >
+    Cerrar sesión
+  </button>
   <ul class="space-y-2">
     <li>
-      <a (click)="closeMenu.emit()" routerLink="/calendar" routerLinkActive="font-bold" class="block">Calendario</a>
+      <a (click)="closeMenu.emit()" routerLink="/calendar" routerLinkActive="font-bold" class="block">
+        <span class="mr-2">📅</span> Calendario
+      </a>
     </li>
     <li>
-      <a (click)="closeMenu.emit()" routerLink="/exercises" routerLinkActive="font-bold" class="block">Ejercicios</a>
+      <a (click)="closeMenu.emit()" routerLink="/exercises" routerLinkActive="font-bold" class="block">
+        <span class="mr-2">🏋️‍♂️</span> Ejercicios
+      </a>
     </li>
   </ul>
 </nav>

--- a/src/app/shared/components/side-menu/side-menu.component.ts
+++ b/src/app/shared/components/side-menu/side-menu.component.ts
@@ -1,8 +1,15 @@
 
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Output, inject } from '@angular/core';
+import {
+  animate,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
 
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { AuthService } from '../../../core/services/auth.service';
 
 @Component({
   selector: 'app-side-menu',
@@ -10,9 +17,27 @@ import { RouterModule } from '@angular/router';
   imports: [CommonModule, RouterModule],
   templateUrl: './side-menu.component.html',
   styleUrls: ['./side-menu.component.scss'],
+  animations: [
+    trigger('slideInOut', [
+      transition(':enter', [
+        style({ transform: 'translateX(-100%)' }),
+        animate('300ms ease-out', style({ transform: 'translateX(0)' })),
+      ]),
+      transition(':leave', [
+        animate('300ms ease-in', style({ transform: 'translateX(-100%)' })),
+      ]),
+    ]),
+  ],
 })
 
 export class SideMenuComponent {
   @Output() closeMenu = new EventEmitter<void>();
+
+  auth = inject(AuthService);
+
+  logout() {
+    this.auth.logout();
+    this.closeMenu.emit();
+  }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { AppComponent } from './app/app.component';
 import { appRoutes } from './app/app.routes';
@@ -9,5 +10,6 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideHttpClient(withInterceptors([authInterceptor])),
     provideRouter(appRoutes),
+    provideAnimations(),
   ],
 });


### PR DESCRIPTION
## Summary
- center the header title and keep login link on the right
- move welcome message and logout button into the side menu
- add icons to sidebar links

## Testing
- `npm test` *(fails: ng not found)*


------
https://chatgpt.com/codex/tasks/task_e_684861bc6c24832498bf9079b3b5ccfe